### PR TITLE
Fix run as administrator capitalisation

### DIFF
--- a/Win11-RAMDisk-Admin-Fix.reg
+++ b/Win11-RAMDisk-Admin-Fix.reg
@@ -15,7 +15,7 @@
 ; December 8, 2024
 
 [HKEY_CLASSES_ROOT\exefile\shell\RunAsAdminInRAMDisk]
-"MUIVerb"="Run as Administrator (RAM Disk Fix)"
+"MUIVerb"="Run as administrator (RAM Disk Fix)"
 
 [HKEY_CLASSES_ROOT\exefile\shell\RunAsAdminInRAMDisk\command]
 @="powershell -Command \"Start-Process cmd -ArgumentList '/c start \\\"\\\" \\\"%1\\\"'\" -Verb runAs\""


### PR DESCRIPTION
Fix run as administrator capitalisation

Spell "administrator" with lower case to match the default spelling used
in Windows.

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>