### PR TITLE
Add access key to context menu command

### DIFF
--- a/Win11-RAMDisk-Admin-Fix.reg
+++ b/Win11-RAMDisk-Admin-Fix.reg
@@ -15,7 +15,7 @@
 ; December 8, 2024
 
 [HKEY_CLASSES_ROOT\exefile\shell\RunAsAdminInRAMDisk]
-"MUIVerb"="Run as Administrator (RAM Disk Fix)"
+"MUIVerb"="Run as Administrator (RAM Disk &Fix)"
 
 [HKEY_CLASSES_ROOT\exefile\shell\RunAsAdminInRAMDisk\command]
 @="powershell -Command \"Start-Process cmd -ArgumentList '/c start \\\"\\\" \\\"%1\\\"'\" -Verb runAs\""


### PR DESCRIPTION
Add access key to context menu command

Allow to quickly launch the right-click context menu command by pressing
the letter "f".

Signed-off-by: Tomasz Wilczyński <twilczynski@naver.com>